### PR TITLE
Recommend G6 instead of G5 on EMR

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -77,12 +77,12 @@ object InstanceInfo {
 // format (numGpus, numCores) -> InstanceInfo about that CSP node instance type
 object PlatformInstanceTypes {
 
-  val AWS_BY_GPUS_CORES = Map((1, 4) -> InstanceInfo(4, 16 * 1024, "g5.xlarge", 1),
-    (1, 8) -> InstanceInfo(8, 32 * 1024, "g5.2xlarge", 1),
-    (1, 16) -> InstanceInfo(16, 64 * 1024, "g5.4xlarge", 1),
-    (1, 32) -> InstanceInfo(32, 128 * 1024, "g5.8xlarge", 1),
-    (4, 48) -> InstanceInfo(48, 192 * 1024, "g5.12xlarge", 1),
-    (1, 64) -> InstanceInfo(64, 256 * 1024, "g5.16xlarge", 1)
+  val AWS_BY_GPUS_CORES = Map((1, 4) -> InstanceInfo(4, 16 * 1024, "g6.xlarge", 1),
+    (1, 8) -> InstanceInfo(8, 32 * 1024, "g6.2xlarge", 1),
+    (1, 16) -> InstanceInfo(16, 64 * 1024, "g6.4xlarge", 1),
+    (1, 32) -> InstanceInfo(32, 128 * 1024, "g6.8xlarge", 1),
+    (4, 48) -> InstanceInfo(48, 192 * 1024, "g6.12xlarge", 1),
+    (1, 64) -> InstanceInfo(64, 256 * 1024, "g6.16xlarge", 1)
   )
 
   // Standard_NC4as_T4_v3 - only recommending nodes with T4's for now, add more later

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -77,7 +77,7 @@ object InstanceInfo {
 // format (numGpus, numCores) -> InstanceInfo about that CSP node instance type
 object PlatformInstanceTypes {
 
-  // Using G6 instances for EMR and AWS
+  // Using G6 instances for EMR
   val EMR_BY_GPUS_CORES = Map((1, 4) -> InstanceInfo(4, 16 * 1024, "g6.xlarge", 1),
     (1, 8) -> InstanceInfo(8, 32 * 1024, "g6.2xlarge", 1),
     (1, 16) -> InstanceInfo(16, 64 * 1024, "g6.4xlarge", 1),

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -77,12 +77,23 @@ object InstanceInfo {
 // format (numGpus, numCores) -> InstanceInfo about that CSP node instance type
 object PlatformInstanceTypes {
 
-  val AWS_BY_GPUS_CORES = Map((1, 4) -> InstanceInfo(4, 16 * 1024, "g6.xlarge", 1),
+  // Using G6 instances for EMR and AWS
+  val EMR_BY_GPUS_CORES = Map((1, 4) -> InstanceInfo(4, 16 * 1024, "g6.xlarge", 1),
     (1, 8) -> InstanceInfo(8, 32 * 1024, "g6.2xlarge", 1),
     (1, 16) -> InstanceInfo(16, 64 * 1024, "g6.4xlarge", 1),
     (1, 32) -> InstanceInfo(32, 128 * 1024, "g6.8xlarge", 1),
     (4, 48) -> InstanceInfo(48, 192 * 1024, "g6.12xlarge", 1),
     (1, 64) -> InstanceInfo(64, 256 * 1024, "g6.16xlarge", 1)
+  )
+
+  // Using G5 instances. To be updated once G6 availability on Databricks
+  // is consistent
+  val DATABRICKS_AWS_BY_GPUS_CORES = Map((1, 4) -> InstanceInfo(4, 16 * 1024, "g5.xlarge", 1),
+    (1, 8) -> InstanceInfo(8, 32 * 1024, "g5.2xlarge", 1),
+    (1, 16) -> InstanceInfo(16, 64 * 1024, "g5.4xlarge", 1),
+    (1, 32) -> InstanceInfo(32, 128 * 1024, "g5.8xlarge", 1),
+    (4, 48) -> InstanceInfo(48, 192 * 1024, "g5.12xlarge", 1),
+    (1, 64) -> InstanceInfo(64, 256 * 1024, "g5.16xlarge", 1)
   )
 
   // Standard_NC4as_T4_v3 - only recommending nodes with T4's for now, add more later
@@ -559,7 +570,7 @@ class DatabricksAwsPlatform(gpuDevice: Option[GpuDevice],
   override val defaultGpuDevice: GpuDevice = A10GGpu
 
   override def getInstanceByResourcesMap: Map[(Int, Int), InstanceInfo] = {
-    PlatformInstanceTypes.AWS_BY_GPUS_CORES
+    PlatformInstanceTypes.DATABRICKS_AWS_BY_GPUS_CORES
   }
 }
 
@@ -629,7 +640,7 @@ class EmrPlatform(gpuDevice: Option[GpuDevice],
   }
 
   override def getInstanceByResourcesMap: Map[(Int, Int), InstanceInfo] = {
-    PlatformInstanceTypes.AWS_BY_GPUS_CORES
+    PlatformInstanceTypes.EMR_BY_GPUS_CORES
   }
 }
 

--- a/user_tools/tests/spark_rapids_tools_e2e/features/installation_checks.feature
+++ b/user_tools/tests/spark_rapids_tools_e2e/features/installation_checks.feature
@@ -29,7 +29,7 @@ Feature: Tool Installation Checks
     Examples:
       | platform         | cli    | expected_stdout                 |
       | dataproc         | gcloud | 2 x n1-standard-16 (1 T4 each)  |
-      | emr              | aws    | 2 x g5.4xlarge                  |
+      | emr              | aws    | 2 x g6.4xlarge                  |
       | databricks-aws   | aws    | 2 x g5.4xlarge                  |
       | databricks-azure | az     | 2 x Standard_NC16as_T4_v3       |
 


### PR DESCRIPTION
This PR fixes #1512

Description of the changes -
1. This PR changes the instances definition for EMR platform to use and recommend G5 GPUs instead of G6
2. Databricks_AWS will still recommend g5 till the availability of G6 instances is consistent